### PR TITLE
Scripts for packaging Linux release

### DIFF
--- a/tools/kroniax-launcher.sh
+++ b/tools/kroniax-launcher.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Launcher in case dependencies are not avaible on the user system
+# If dependencies are already installed, no need to use this script
+
+LIBS_DIR=./lib32
+EXECUTABLE=./Kroniax
+
+LD_LIBRARY_PATH="$LIBS_DIR":"$LD_LIBRARY_PATH" "$EXECUTABLE"
+

--- a/tools/linux-release.sh
+++ b/tools/linux-release.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# -= stand-alone release builder for Linux =-
+
+
+# Go to the root directory of the git repository
+PATH_TO_ROOT=$(git rev-parse --show-cdup)
+if [ $PATH_TO_ROOT ]; then
+	cd $PATH_TO_ROOT
+fi
+
+# Get project name from directory and ensure lowercase
+PROJECT_NAME=$(basename $(pwd) | tr '[A-Z]' '[a-z]')
+
+# Ask which version to build (will be included in filename)
+read -p "Enter version number: " VERSION
+
+# Name of the directory which will contain the release
+TARGET_NAME="$PROJECT_NAME"_"$VERSION"-linux
+echo Packaging  $TARGET_NAME.tar.gz...
+
+# Copy SFML libraries
+mkdir lib32
+cp /usr/local/lib/libsfml* lib32
+
+# Copy launcher script
+cp tools/kroniax-launcher.sh .
+
+# Create tarball from the bin directory and rename it as TARGET_NAME
+ARCHIVE_CONTENT="./Kroniax ./README.md ./LICENSE.txt ./kroniax-launcher.sh ./config ./data ./levels ./lib32"
+tar -czf $TARGET_NAME.tar.gz $ARCHIVE_CONTENT --transform=s/\./$TARGET_NAME/ 
+
+# Clean up the mess 
+rm -r lib32
+rm kroniax-launcher.sh
+
+echo Done!
+


### PR DESCRIPTION
Added a script for generating a release tarball for Linux systems, ready to be redistributed.
The package generated is a stand alone and should run on systems where SFML is not installed.

The tarball will contain:
- Executable and assets
- SFML .so files
- A shell launcher

The launcher adds the SFML .so files to the LD_LIBRARY_PATH and then invokes the executable.

Usage:

```
$ ./tools/linux-release.sh 
Enter version number: 0.5.2
Packaging kroniax_0.5.2-linux.tar.gz...
Done!
```

Currently the script looks for SFML .so files only in `/usr/local/lib`, so this point could be improved.
