### PR TITLE
Improved linux packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(
 	${SRC_DIR}/game/Menu.cpp
 	${SRC_DIR}/game/MenuBackground.cpp
 	${SRC_DIR}/game/Settings.cpp
+	${SRC_DIR}/game/Tracer.cpp
 	${SRC_DIR}/gui/GuiBaseClass.cpp
 	${SRC_DIR}/gui/GuiController.cpp
 	${SRC_DIR}/gui/GuiLayer.cpp

--- a/tools/kroniax-launcher.sh
+++ b/tools/kroniax-launcher.sh
@@ -3,7 +3,7 @@
 # Launcher in case dependencies are not avaible on the user system
 # If dependencies are already installed, no need to use this script
 
-LIBS_DIR=./lib32
+LIBS_DIR=./lib
 EXECUTABLE=./Kroniax
 
 LD_LIBRARY_PATH="$LIBS_DIR":"$LD_LIBRARY_PATH" "$EXECUTABLE"

--- a/tools/make-linux-release.sh
+++ b/tools/make-linux-release.sh
@@ -8,29 +8,32 @@ if [ $PATH_TO_ROOT ]; then
 	cd $PATH_TO_ROOT
 fi
 
-# Get project name from directory and ensure lowercase
+# Get project name from directory 
 PROJECT_NAME=$(basename $(pwd) | tr '[A-Z]' '[a-z]')
 
 # Ask which version to build (will be included in filename)
 read -p "Enter version number: " VERSION
 
+ARCH=$(uname -m)
+KERNEL=$(uname -s | tr '[A-Z]' '[a-z]')
+
 # Name of the directory which will contain the release
-TARGET_NAME="$PROJECT_NAME"_"$VERSION"-linux
+TARGET_NAME="$PROJECT_NAME"_"$VERSION"-"$KERNEL"_"$ARCH"
 echo Packaging  $TARGET_NAME.tar.gz...
 
 # Copy SFML libraries
-mkdir lib32
-cp /usr/local/lib/libsfml* lib32
+mkdir lib
+cp /usr/local/lib/libsfml* lib
 
 # Copy launcher script
 cp tools/kroniax-launcher.sh .
 
-# Create tarball from the bin directory and rename it as TARGET_NAME
-ARCHIVE_CONTENT="./Kroniax ./README.md ./LICENSE.txt ./kroniax-launcher.sh ./config ./data ./levels ./lib32"
+# Create tarball and rename it as TARGET_NAME
+ARCHIVE_CONTENT="./Kroniax ./README.md ./LICENSE.txt ./kroniax-launcher.sh ./config ./data ./levels ./lib"
 tar -czf $TARGET_NAME.tar.gz $ARCHIVE_CONTENT --transform=s/\./$TARGET_NAME/ 
 
 # Clean up the mess 
-rm -r lib32
+rm -r lib
 rm kroniax-launcher.sh
 
 echo Done!


### PR DESCRIPTION
I've finally set up a 64 bits environment and improved the packaging script so the arch name of the building machine is included in the tarball.
It will looks like:
- kroniax_0.5.2-linux_x86_64.tar.gz
- kroniax_0.5.2-linux_i686.tar.gz

Also fixed CMakeLists.txt (Tracer.cpp was missing).
