### PR TITLE
minor adjustment

### DIFF
--- a/include/gui/guiBaseClass.cpp
+++ b/include/gui/guiBaseClass.cpp
@@ -31,8 +31,7 @@ namespace aw
 	void GuiBaseElement::handleEvent(const sf::Event &e)
 	{
 		switch (m_type)
-		{
-        default:
+		{        
 		case GUI_LIST:
 			if (e.type == sf::Event::KeyPressed)
 			{
@@ -102,6 +101,7 @@ namespace aw
 				}
 			}
 			break;
+        default: break;
 		}
 	}
 


### PR DESCRIPTION
`default:` was introduced to eliminate compiler warning, now making sure the switch statement remains functionally the same.
